### PR TITLE
Updated Alpha Processing for Non-Premultiplied

### DIFF
--- a/src/Gleed2D.Core/Constants.cs
+++ b/src/Gleed2D.Core/Constants.cs
@@ -50,6 +50,7 @@ namespace Gleed2D.Core
 			GridLineThickness = 1 ;
 			GridNumberOfGridLines = 500 ;
 			GridSpacing = new Vector2( 64, 64 ) ;
+            PremultipliedAlpha = true;
 		}
 
 		[Editor( typeof( XnaColorUiTypeEditor ), typeof( System.Drawing.Design.UITypeEditor ) )]
@@ -205,6 +206,14 @@ namespace Gleed2D.Core
 			get ;
 			set ;
 		}
+
+        [Category("Image Handling"),
+         Description("If transparent images use premultiplied alpha transparency. Restart required.")]
+        public bool PremultipliedAlpha
+        {
+            get;
+            set;
+        }
 
 		public bool RunLevelStartApplication ;
 		public string RunLevelApplicationToStart ;

--- a/src/Gleed2D.Core/TextureStore.cs
+++ b/src/Gleed2D.Core/TextureStore.cs
@@ -3,6 +3,8 @@ using System.Collections.Generic ;
 using System.Reflection ;
 using Microsoft.Xna.Framework.Graphics ;
 using System.IO ;
+using Microsoft.Xna.Framework.Graphics.PackedVector;
+using Microsoft.Xna.Framework;
 
 namespace Gleed2D.Core
 {
@@ -22,15 +24,52 @@ namespace Gleed2D.Core
 		{
 			if( !_textures.ContainsKey( fullPathToFile ) )
 			{
-				var stream = new FileStream( fullPathToFile, FileMode.Open, FileAccess.Read, FileShare.ReadWrite ) ;
-		
-				_textures[ fullPathToFile ] = Texture2D.FromStream( gd, stream ) ;
+				var stream = new FileStream( fullPathToFile, FileMode.Open, FileAccess.Read, FileShare.ReadWrite );
+                
+                Texture2D loadedTexture = Texture2D.FromStream(gd, stream);
+
+                _textures[fullPathToFile] = processTexture(loadedTexture);
 				
-				stream.Close( ) ;
+				stream.Close( );
 			}
 
-			return _textures[ fullPathToFile ] ;
+			return _textures[ fullPathToFile ];
 		}
+
+        private Texture2D processTexture(Texture2D texture)
+        {
+            //Some programs such as Photoshop save PNG and other RGBA images without premultiplied alpha
+            if (!Constants.Instance.PremultipliedAlpha)
+            {
+
+                //XNA 4.0+ assumes that all RGBA images have premultiplied alpha channels.
+                //Code snippet borrowed from http://xboxforums.create.msdn.com/forums/p/62320/383015.aspx#485897
+
+                Byte4[] data = new Byte4[texture.Width * texture.Height];
+                texture.GetData<Byte4>(data);
+                for (int i = 0; i < data.Length; i++)
+                {
+                    Vector4 vec = data[i].ToVector4();
+                    float alpha = vec.W / 255.0f;
+                    int a = (int)(vec.W);
+                    int r = (int)(alpha * vec.X);
+                    int g = (int)(alpha * vec.Y);
+                    int b = (int)(alpha * vec.Z);
+                    uint packed = (uint)(
+                        (a << 24) +
+                        (b << 16) +
+                        (g << 8) +
+                        r
+                        );
+
+                    data[i].PackedValue = packed;
+                }
+
+                texture.SetData<Byte4>(data);
+            }
+
+            return texture;
+        }
 
 		public void Clear()
 		{

--- a/src/Level.cs
+++ b/src/Level.cs
@@ -10,6 +10,8 @@ using Gleed2D.Core.CustomUITypeEditors;
 using Gleed2D.InGame ;
 using Microsoft.Xna.Framework ;
 using StructureMap ;
+using System.Xml;
+using System.Text;
 
 namespace Gleed2D.Core
 {
@@ -269,9 +271,15 @@ Would you like to change it?".FormatWith( _properties.ContentRootFolder ) ;
 
 			_properties.CameraPosition = editor.Camera.Position ;
 
-			var document = ToXml( ) ;
+			XElement document = ToXml( ) ;
 
-			document.Save( filename ) ;
+            System.Xml.XmlWriterSettings settings = new System.Xml.XmlWriterSettings();
+            settings.Encoding = new UTF8Encoding(false); //This byte mark encoding isn't handled nicely by some programs
+            settings.Indent = true; //Keeping the previous indent
+
+            using (XmlWriter writer = XmlTextWriter.Create(filename,settings) ) {
+                document.Save(writer);
+            }
 		}
 
 		AttributeCollection ICustomTypeDescriptor.GetAttributes()


### PR DESCRIPTION
-- Adding a setting that will globally flag if imported images have premultiplied alpha channels or not. Default value is previous behavior.
-- Updating texture loading to modify the alpha channel if configured for non-premultiplied images
